### PR TITLE
Add a specfile for rpm builds.

### DIFF
--- a/redhat/ldap-git-backup.spec
+++ b/redhat/ldap-git-backup.spec
@@ -1,0 +1,44 @@
+Name:           ldap-git-backup
+Summary:        Back up LDAP database in an Git repository
+Version:        1.0.7
+Release:        1
+License:        GPLv3+
+Url:            https://github.com/elmar/ldap-git-backup
+BuildArch:      noarch
+Source:         https://github.com/elmar/ldap-git-backup/archive/%{version}-%{release}.tar.gz
+BuildRequires:  autoconf
+BuildRequires:  automake
+AutoReq:        yes
+
+%description
+ldap-git-backup (creates and) updates a Git repository which contains the
+current LDIF dump of an LDAP directory.  Given that writes are rare in an LDAP
+directory and confined to a few entries for each write Git will store the
+entire history of an LDAP directory in a space efficient way.
+By default the backups are done with slapcat from OpenLDAP but can be done
+with any command that dumps the current contents of an LDAP directory in LDIF
+format.
+
+%prep
+%setup -q -n %{name}-%{version}-%{release}
+
+%build
+autoreconf -i
+./configure --prefix %{_prefix}
+
+%install
+make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_prefix} \
+     BINDIR=%{_bindir} SYSCONFDIR=%{_sysconfdir} \
+     MANDIR=%{_mandir} \
+     install
+
+
+%files
+%doc README.mdown COPYING
+%{_sbindir}/ldap-git-backup
+%{_sbindir}/safe-ldif
+%doc %{_mandir}/man1/*
+
+%changelog
+* Fri Dec 11 2015 Matthew Richardson <m.richardson@ed.ac.uk> - 1.0.7-1
+- Initial specfile


### PR DESCRIPTION
I've quickly put together a spec file as requested in #1 to allow the building of an ldap-git-backup rpm.

It assumes a source `.tar.gz` as supplied on the releases page of github, using `autoreconf -i` as suggested.

It uses the `AutoReq` specfile option to scan through the code and pick up on the appropriate dependencies (i.e all the perl modules).

I've tested both compiling from the specfile and the resulting installed package on RHEL 6 and 7 and it all works as expected, though it probably isn't quite tidy enough for submission to EPEL.
