### PR TITLE
Don't list changed files on the command line

### DIFF
--- a/ldap-git-backup.in
+++ b/ldap-git-backup.in
@@ -63,8 +63,7 @@ sub main {
         push(@filelist, $filename);
         delete($files_before{$filename});
     }
-    $repo->command('add', @filelist) if @filelist;
-    $repo->command('rm', (keys %files_before)) if %files_before;
+    $repo->command('add', '-A');
 
     $repo->command('commit', "--message=$commit_msg", "--date=$commit_date");
     $repo->command('gc', '--quiet') if $gc;


### PR DESCRIPTION
For very large change sets, listing them on the command line exceeds the maximum command line length. This change lets git pick up the changed files instead.

Fixes #4