### PR TITLE
Fix variable name in example script

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -82,7 +82,7 @@ Here is some example code that may serve as a start:
             --backup-dir $BKUP_DIR \
             --commit-msg $filename \
             --commit-date $filepath
-        mv $path DONE/$filename
+        mv $filepath DONE/$filename
     done
 
 To use this script you put all compressed old LDIF file in a subdirectory <code>TODO</code> of some directory where you keep the backups.  You must also create another directory <code>DONE</code> where the processed backups will be moved into.  Furthermore, the script assumes that the backup files still have their original modification time of when the backup was performed.  This is used to sort the files and to set the commit date.

--- a/examples/migrate-ldif
+++ b/examples/migrate-ldif
@@ -19,5 +19,5 @@ for filepath in `ls -1tr $LDIF_DIR/TODO/*.gz` ; do
         --backup-dir $BKUP_DIR \
         --commit-msg $filename \
         --commit-date $filepath
-    mv $path DONE/$filename
+    mv $filepath DONE/$filename
 done


### PR DESCRIPTION
Otherwise, moving processed files to the DONE directory doesn't work and results in error messages because the `$path` variable isn't defined and thus empty.