### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ldap-git-backup (1.0.8-2) UNRELEASED; urgency=medium
+
+  * Apply multi-arch hints.
+    + ldap-git-backup: Add :any qualifier for perl dependency.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 27 Oct 2020 23:55:23 -0000
+
 ldap-git-backup (1.0.8-1) unstable; urgency=medium
 
   * New minor upstream release

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Rules-Requires-Root: no
 Package: ldap-git-backup
 Architecture: all
 Depends: git,
-         perl,
+         perl:any,
          perl-doc,
          ${misc:Depends}
 Suggests: slapd


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* ldap-git-backup: Add :any qualifier for perl dependency. This fixes: ldap-git-backup could have its dependency on perl annotated with :any. ([dep-any](https://wiki.debian.org/MultiArch/Hints#dep-any))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/ldap-git-backup/4e966dda-5743-4610-9bd8-9565ef533199.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Depends: git, [-perl,-] {+perl:any,+} perl-doc


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/4e966dda-5743-4610-9bd8-9565ef533199/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/4e966dda-5743-4610-9bd8-9565ef533199/diffoscope)).
