### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Rules-Requires-Root: no
 Package: ldap-git-backup
 Architecture: all
 Depends: git,
-         perl,
+         perl:any,
          perl-doc,
          ${misc:Depends}
 Suggests: slapd


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.

Note that in some cases, these multi-arch hints may trigger lintian warnings
until the dependencies of the package support multi-arch. This is expected,
see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.



This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/ldap-git-backup/6a5b6740-a766-4267-b846-49acd00701a3.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Depends: git, [-perl,-] {+perl:any,+} perl-doc


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/6a5b6740-a766-4267-b846-49acd00701a3/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/6a5b6740-a766-4267-b846-49acd00701a3/diffoscope)).
